### PR TITLE
use Adobe group Id, plus more flexible AdobeApi-async test

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,15 +7,18 @@ let vendors = lg.getActiveVendors();
 let logger = require('./services/logger');
 
 logger.info('starting app');
+logger.info('vendors activated in config/appConf.js:' + vendors);
 
 (async () => {
   if (vendors.includes('Adobe')) {
     logger.info('starting Adobe service from app.js');
     await adobe();
+    // logger.info('Adobe service finished from app.js');
   }
 
   if (vendors.includes('Jamf')) {
     logger.info('starting jamf service from app.js');
     await jamf();
+    // logger.info('jamf service finished from app.js');
   }
 })();

--- a/config/appConf.sample.js
+++ b/config/appConf.sample.js
@@ -52,16 +52,32 @@ module.exports = {
   },
   software: [
     {
-      provider: 'Adobe', // 'Adobe' is currently the only supported value, but that could change in the future
-      name: 'Adobe Photoshop', // REPLACE WITH the LIbCal name for the product
-      shortName: 'photoshop', // Short name for your own convenience
-      adobeGroupName: 'MyLibrary Photoshop Patrons', // REPLACE WITH the Adobe User Mgmt User Group Name
+      vendor: 'Adobe', // 'Adobe' and 'Jamf' are currently the only supported values
+      vendorGroupName: 'MyLibrary Photoshop Patrons', // REPLACE WITH the Adobe User Mgmt User Group Name
+      vendorGroupId: '123456789', // REPLACE WITH the Adobe User Mgmt User Group ID
+      libCalName: 'Adobe Photoshop', // REPLACE WITH the LIbCal name for the product
+      libCalCid: '12345', // REPLACE WITH the LIbCal CID for the product
+      active: true,
+      // you can add other fields here for your own use that don't affect the software checkout process
+      // such as:
+      // reservationUrl:
+      //   'https://yourlib.libcal.com/reserve/LibrarySoftware/photoshop',
     },
     {
-      provider: 'Adobe', // 'Adobe' is currently the only supported value, but that could change in the future
-      name: 'Adobe Illustrator', // REPLACE WITH the LIbCal name for the product
-      shortName: 'illustrator',
-      adobeGroupName: 'MyLibrary Illustrator Patrons', // REPLACE WITH the Adobe User Mgmt User Group Name
+      vendor: 'Adobe', // 'Adobe' and 'Jamf' are currently the only supported values
+      vendorGroupId: 'MyLibrary Illustrator Patrons', // REPLACE WITH the Adobe User Mgmt User Group Name
+      vendorGroupId: '012345678', // REPLACE WITH the Adobe User Mgmt User Group ID
+      libCalName: 'Adobe Illustrator', // REPLACE WITH the LIbCal name for the product
+      libCalCid: '67890', // REPLACE WITH the LIbCal CID for the product
+      active: false,
+    },
+    {
+      vendor: 'Jamf', // 'Adobe' and 'Jamf' are currently the only supported values
+      vendorGroupName: 'Logic Pro', // REPLACE WITH the Jamf User Group Name
+      vendorGroupId: 8,
+      libCalName: 'Logic Pro',
+      libCalCid: '12345',
+      active: true,
     },
   ],
 };

--- a/config/test/.gitignore
+++ b/config/test/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except these files
+!.gitignore
+!*.sample.js

--- a/config/test/adobe.testConf.sample.js
+++ b/config/test/adobe.testConf.sample.js
@@ -1,0 +1,33 @@
+module.exports = {
+  testGroup: {
+    vendor: 'Adobe',
+    libCalName: 'Adobe Creative Cloud',
+    libCalCid: '42038',
+    vendorGroupName: 'Library API/test',
+    vendorGroupId: '118220133',
+    active: true,
+  },
+  // one real user email
+  emailsToAdd1: ['qum@miamioh.edu'],
+
+  // two real user emails
+  emailsToAdd2: ['qum@miamioh.edu', 'brownsj1@miamioh.edu'],
+
+  // one fake user email
+  emailsFake1: ['thisissuchafakeemail@miamioh.edu'],
+
+  // 11 real users emails
+  emailsBigList: [
+    'qum@miamioh.edu',
+    'yarnete@miamioh.edu',
+    'irwinkr@miamioh.edu',
+    'maderir@miamioh.edu',
+    'kerre2@miamioh.edu',
+    'brownsj1@miamioh.edu',
+    'bomholmm@miamioh.edu',
+    'wisnesr@miamioh.edu',
+    'calabrcm@miamioh.edu',
+    'conleyj@miamioh.edu',
+    'wegnera3@miamioh.edu',
+  ],
+};

--- a/demo/adobe.demo.js
+++ b/demo/adobe.demo.js
@@ -16,8 +16,9 @@ const { mainMenu } = require('./mainMenu');
 
 const adobeSoftware = software
   .filter((item) => item.vendor == 'Adobe')
-  .map(({ vendorGroupName, active }) => ({
+  .map(({ vendorGroupName, vendorGroupId, active }) => ({
     vendorGroupName,
+    vendorGroupId,
     active,
   }));
 
@@ -30,8 +31,8 @@ const chooseGroup = async (verb) => {
     genList({
       list: adobeSoftware,
       message: `${verb} users in which group?`,
-      itemNameProp: 'vendorGroupName',
-      itemValueProp: 'vendorGroupName',
+      itemNameProp: 'vendorGroupName', // display this
+      itemValueProp: 'vendorGroupId', // return this
       outputLabel: 'groupName',
     })
   );

--- a/demo/email.demo.js
+++ b/demo/email.demo.js
@@ -1,0 +1,25 @@
+/* test email converter */
+const UniqEmailRepo = require('../repositories/UniqEmailRepository');
+const emailRepo = new UniqEmailRepo();
+const EmailConverterRepository = require('../repositories/EmailConverterRepository');
+const appConf = require('../config/appConf');
+const convertRepo = new EmailConverterRepository(appConf);
+const emailConverterService = require('../services/emailConverterService');
+const database = require('../helpers/database');
+const UniqEmail = require('../models/UniqEmail');
+
+(async () => {
+  /* Test connection */
+  await database.connect();
+  // let res = await UniqEmail.find();
+  let res = await emailRepo.queryAllEmails();
+  console.log(res);
+  await database.disconnect();
+
+  // await emailRepo.connect();
+  // lookfor = ['jerry.yarnetsky@miamioh.edu', 'ken.irwin@miamioh.edu'];
+  // // emails = await emailRepo.queryAllEmails();
+  // emails = await emailRepo.querySpecificEmails(lookfor);
+  // console.log(emailRepo.getKnownAndUnknownEmails(lookfor, emails));
+  // await emailRepo.disconnect();
+})();

--- a/demo/mainMenu.js
+++ b/demo/mainMenu.js
@@ -1,3 +1,4 @@
+// This file is used by adobe.demo.js and james.demo.js to display the main menu options
 const inquirer = require('inquirer');
 const mainMenu = () => {
   console.log();

--- a/models/AdobeApi.js
+++ b/models/AdobeApi.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const debug = require('debug')('AdobeApi');
 const { axiosLogPrep } = require('../helpers/utils');
+const fetch = require('node-fetch');
 
 module.exports = class AdobeUserMgmtApi {
   constructor(conf) {
@@ -25,7 +26,7 @@ module.exports = class AdobeUserMgmtApi {
       let grantType = 'client_credentials';
       let scope = 'openid,AdobeID,user_management_sdk';
 
-      var myHeaders = new Headers();
+      var myHeaders = new fetch.Headers();
       myHeaders.append('Content-Type', 'application/x-www-form-urlencoded');
 
       var urlencoded = new URLSearchParams();

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jsonwebtoken": "^9.0.1",
     "lodash": "^4.17.21",
     "mongoose": "^5.12.8",
+    "node-fetch": "^3.3.2",
     "object-to-xml": "^2.0.0",
     "process": "^0.11.10",
     "querystring": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "jsonwebtoken": "^9.0.1",
     "lodash": "^4.17.21",
     "mongoose": "^5.12.8",
-    "node-fetch": "^3.3.2",
+    "node-fetch": "^2.7.0",
     "object-to-xml": "^2.0.0",
     "process": "^0.11.10",
     "querystring": "^0.2.0",

--- a/repositories/AdobeRepository.js
+++ b/repositories/AdobeRepository.js
@@ -57,12 +57,14 @@ module.exports = class AdobeUserMgmtService {
     this.queryConf.url =
       this.baseUrl + 'users' + '/' + this.credentials.orgId + '/0/' + group;
     this.queryConf.method = 'GET';
+    // console.log('queryConf: ' + JSON.stringify(this.queryConf));
     debug('getGroupMembers query conf: ' + this.queryConf);
     let res = await this.getPaginatedResults('users');
     return res;
   }
 
   getEmailsFromGroupMembers(data) {
+    if (!data || data.length == 0) return [];
     return data.map((i) => i.email);
   }
 

--- a/services/adobeService.js
+++ b/services/adobeService.js
@@ -25,7 +25,7 @@ module.exports = async () => {
 
   asyncForEach(software, async (pkg) => {
     logger.info(
-      `Getting libCalCid (pid:${pid}): ${pkg.libCalCid}, vendorGroupName: ${pkg.vendorGroupName}`
+      `Getting libCalCid (pid:${pid}): ${pkg.libCalCid}, vendorGroupName: ${pkg.vendorGroupName}, vendorGroupId: ${pkg.vendorGroupId}`
     );
 
     // get libCalList based on pkg.libCalCid
@@ -36,9 +36,13 @@ module.exports = async () => {
       content: libCalEmails,
     });
     // // get adobe list based on pkg.vendorGroupName
-    let currAdobeEntitlements = await adobe.getGroupMembers(
-      pkg.vendorGroupName
-    );
+    let group;
+    if (pkg.hasOwnProperty('vendorGroupId')) {
+      group = pkg.vendorGroupId;
+    } else {
+      group = pkg.vendorGroupName;
+    }
+    let currAdobeEntitlements = await adobe.getGroupMembers(group);
     logger.info(
       `length of currAdobeEntitlements: ${currAdobeEntitlements.length} (pid:${pid})`
     );
@@ -96,7 +100,7 @@ module.exports = async () => {
       content: emailsToAdd,
     });
     if (emailsToAdd.length > 0) {
-      res = await adobe.addGroupMembers(emailsToAdd, pkg.vendorGroupName);
+      res = await adobe.addGroupMembers(emailsToAdd, group);
       logger.info(`Response from Adobe add request (pid:${pid})`, {
         status: res.status,
       });

--- a/services/adobeService.js
+++ b/services/adobeService.js
@@ -22,8 +22,13 @@ let pid = process.pid;
 
 module.exports = async () => {
   logger.info('starting AdobeService');
+  let i = 0;
 
   asyncForEach(software, async (pkg) => {
+    i++;
+    logger.info(
+      `starting AdobeService for ${pkg.vendorGroupName} (pid:${pid}-${i})`
+    );
     logger.info(
       `Getting libCalCid (pid:${pid}): ${pkg.libCalCid}, vendorGroupName: ${pkg.vendorGroupName}, vendorGroupId: ${pkg.vendorGroupId}`
     );
@@ -32,9 +37,12 @@ module.exports = async () => {
     let libCalBookings = await libCal.getCurrentValidBookings(pkg.libCalCid);
     // console.log(pkg.libCalCid, libCalBookings.length);
     let libCalEmails = libCal.getUniqueEmailsFromBookings(libCalBookings);
-    logger.debug(`libCalEmails (Adobe):(pid:${pid}):`, {
-      content: libCalEmails,
-    });
+    logger.debug(
+      `libCalEmails (Adobe group:${pkg.vendorGroupName}):(pid:${pid}-${i}):`,
+      {
+        content: libCalEmails,
+      }
+    );
     // // get adobe list based on pkg.vendorGroupName
     let group;
     if (pkg.hasOwnProperty('vendorGroupId')) {
@@ -44,66 +52,94 @@ module.exports = async () => {
     }
     let currAdobeEntitlements = await adobe.getGroupMembers(group);
     logger.info(
-      `length of currAdobeEntitlements: ${currAdobeEntitlements.length} (pid:${pid})`
+      `length of currAdobeEntitlements: ${currAdobeEntitlements.length} (group:${pkg.vendorGroupName}) (pid:${pid}-${i})`
     );
     // console.log('currAdobeEntitlements:', currAdobeEntitlements.length);
     let currAdobeEmails = adobe.getEmailsFromGroupMembers(
       currAdobeEntitlements
     );
-    logger.debug(`currAdobeEmails:(pid:${pid}):`, { content: currAdobeEmails });
+    logger.debug(
+      `currAdobeEmails (group:${pkg.vendorGroupName}):(pid:${pid}-${i}):`,
+      { content: currAdobeEmails }
+    );
     logger.info(
-      `length of currAdobeEmails: ${currAdobeEmails.length} (pid:${pid})`
+      `length of currAdobeEmails: ${currAdobeEmails.length} (pid:${pid}-${i})`
     );
     // Fake Data: to use this, comment out the code above and uncomment these two lines
     // let libCalBookings = ['irwinkr@miamioh.edu', 'bomholmm@miamioh.edu'];
     // let currAdobeEmails = ['irwinkr@miamioh.edu', 'qum@miamioh.edu'];
 
     // convert emails if necessary
-    logger.info(`starting emailConverterService (pid:${pid})`);
+    logger.info(`Adobe starting emailConverterService (pid:${pid}-${i})`);
     try {
       libCalEmails = await emailConverterService(libCalEmails);
     } catch (err) {
-      logger.error(`failed emailConverterService (pid:${pid})`, { error: err });
+      logger.error(`Adobe failed emailConverterService (pid:${pid}-${i})`, {
+        error: err,
+      });
     }
-    logger.info(`finished emailConverterService (pid:${pid})`);
+    logger.info(`Adobe finished emailConverterService (pid:${pid}-${i})`);
 
-    logger.info(`length of libCalEmails: ${libCalEmails.length} (pid:${pid})`);
+    logger.info(
+      `length of libCalEmails: ${libCalEmails.length} (pid:${pid}-${i})`
+    );
 
-    logger.info(`starting Adobe emailsToRemove (pid:${pid})`);
+    logger.info(
+      `starting Adobe emailsToRemove (group:${pkg.vendorGroupName}) (pid:${pid}-${i})`
+    );
     // compare: get users to remove in Adobe
     let emailsToRemove = filterToEntriesMissingFromSecondArray(
       currAdobeEmails,
       libCalEmails
     );
 
-    logger.info(`starting Adobe emailsToAdd (pid:${pid})`);
+    logger.info(
+      `starting Adobe emailsToAdd (group:${pkg.vendorGroupName}) (pid:${pid}-${i})`
+    );
     // compare: get users to add in Adobe
     let emailsToAdd = filterToEntriesMissingFromSecondArray(
       libCalEmails,
       currAdobeEmails
     );
-    logger.info(`finished Adobe emailsToAdd (pid:${pid})`);
+    logger.info(
+      `finished Adobe emailsToAdd (group:${pkg.vendorGroupName}) (pid:${pid}-${i})`
+    );
 
     // adobe remove
-    logger.info(`Adobe Remove:(pid:${pid}):${emailsToRemove.length}`, {
-      content: emailsToRemove,
-    });
+    logger.info(
+      `Adobe Remove:(group:${pkg.vendorGroupName})(pid:${pid}-${i}):${emailsToRemove.length}`,
+      {
+        content: emailsToRemove,
+      }
+    );
     if (emailsToRemove.length > 0) {
       res = await adobe.removeGroupMembers(emailsToRemove, pkg.vendorGroupName);
-      logger.info(`Response from Adobe remove request(pid:${pid})`, {
-        status: res.status,
-      });
+      logger.info(
+        `Response from Adobe remove request (group:${pkg.vendorGroupName})(pid:${pid}-${i})`,
+        {
+          status: res.status,
+        }
+      );
     }
 
     // adobe add
-    logger.info(`Adobe Add:(pid:${pid}):${emailsToAdd.length}`, {
-      content: emailsToAdd,
-    });
+    logger.info(
+      `Adobe Add:(group:${pkg.vendorGroupName})(pid:${pid}-${i}):${emailsToAdd.length}`,
+      {
+        content: emailsToAdd,
+      }
+    );
     if (emailsToAdd.length > 0) {
       res = await adobe.addGroupMembers(emailsToAdd, group);
-      logger.info(`Response from Adobe add request (pid:${pid})`, {
-        status: res.status,
-      });
+      logger.info(
+        `Response from Adobe add request (group:${pkg.vendorGroupName})(pid:${pid}-${i})`,
+        {
+          status: res.status,
+        }
+      );
     }
+    logger.info(
+      `AdobeService finished for ${pkg.vendorGroupName} (pid:${pid}-${i})`
+    );
   });
 };

--- a/services/emailConverterService.js
+++ b/services/emailConverterService.js
@@ -24,7 +24,10 @@ module.exports = async (emails) => {
   // alternate definition may or may not result in a faster process
   logger.info(`emailConverterService querying db (pid:${pid})`);
   knownEmails = await emailRepo.queryAllEmails();
-  logger.info(`emailConverterService query complete (pid:${pid})`, { queryResults: knownEmails.length });
+  logger.info(`emailConverterService query complete (pid:${pid})`, {
+    queryResults: knownEmails.length,
+  });
+  // let knownEmails = []; //comment this out when you uncomment the above
   let { found, missing } = await emailRepo.getKnownAndUnknownEmails(
     emails,
     knownEmails
@@ -32,14 +35,17 @@ module.exports = async (emails) => {
 
   let authoritativeEmails = found;
 
-  logger.info(`emailConverterService sorting results (pid:${pid})`, { found: found.length, missing: missing.length });
-  let {
-    authFound,
-    authMissing,
-    newMatches,
-  } = await convertRepo.getAuthoritativeEmailsBatch(missing);
+  logger.info(`emailConverterService sorting results (pid:${pid})`, {
+    found: found.length,
+    missing: missing.length,
+  });
+  let { authFound, authMissing, newMatches } =
+    await convertRepo.getAuthoritativeEmailsBatch(missing);
 
-  logger.info(`emailConverterService finished getAuthoritativeEmailsBatch (pid:${pid})`, { found: found.length, missing: missing.length });
+  logger.info(
+    `emailConverterService finished getAuthoritativeEmailsBatch (pid:${pid})`,
+    { found: found.length, missing: missing.length }
+  );
 
   if (newMatches.length > 0) {
     logger.info('adding new emails pairs with', newMatches);

--- a/test/models/AdobeApi-async.test.js
+++ b/test/models/AdobeApi-async.test.js
@@ -3,7 +3,20 @@ const AdobeUserMgmtApi = require('../../models/AdobeApi');
 const AdobeRepo = require('../../repositories/AdobeRepository');
 const api = new AdobeUserMgmtApi(realConf);
 const repo = new AdobeRepo(realConf);
-const testGroupName = 'Library API test';
+const testConf = require('../../config/test/adobe.testConf');
+
+// expect config file to have these properties
+describe('AdobeUserMgmtApi: testConf', () => {
+  it('should have testConf', () => {
+    expect(testConf).toHaveProperty('testGroup');
+    expect(testConf.testGroup).toHaveProperty('vendorGroupName');
+    expect(testConf.testGroup).toHaveProperty('vendorGroupId');
+    expect(testConf).toHaveProperty('emailsToAdd1');
+    expect(testConf).toHaveProperty('emailsToAdd2');
+    expect(testConf).toHaveProperty('emailsFake1');
+    expect(testConf).toHaveProperty('emailsBigList');
+  });
+});
 
 describe('AdobeUserMgmtApi: getToken', () => {
   it('should get an accessToken', async () => {
@@ -24,25 +37,14 @@ describe('AdobeUserMgmtApi: getToken', () => {
 // });
 
 describe('AdobeUserMgmtRepository: addMembersToGroup', () => {
-  emailsToAdd1 = ['qum@miamioh.edu'];
-  emailsToAdd2 = ['qum@miamioh.edu', 'brownsj1@miamioh.edu'];
-  emailsFake1 = ['thisissuchafakeemail@miamioh.edu'];
-  emailsBigList = [
-    'qum@miamioh.edu',
-    'yarnete@miamioh.edu',
-    'irwinkr@miamioh.edu',
-    'maderir@miamioh.edu',
-    'kerre2@miamioh.edu',
-    'brownsj1@miamioh.edu',
-    'bomholmm@miamioh.edu',
-    'wisnesr@miamioh.edu',
-    'calabrcm@miamioh.edu',
-    'conleyj@miamioh.edu',
-    'wegnera3@miamioh.edu',
-  ];
+  emailsToAdd1 = testConf.emailsToAdd1;
+  emailsToAdd2 = testConf.emailsToAdd2;
+  emailsFake1 = testConf.emailsFake1;
+  emailsBigList = testConf.emailsBigList;
+  testGroupId = testConf.testGroup.vendorGroupId;
 
-  it('should be able to fake-add Meng to a list', async () => {
-    let res = await repo.addGroupMembers(emailsToAdd1, testGroupName, 'test');
+  it('should be able to fake-add one user to a list', async () => {
+    let res = await repo.addGroupMembers(emailsToAdd1, testGroupId, 'test');
     expect(res).toHaveProperty('status');
     expect(res.status).toBe('success');
     expect(res).toHaveProperty('message');
@@ -50,7 +52,7 @@ describe('AdobeUserMgmtRepository: addMembersToGroup', () => {
     expect(res.message.completedInTestMode).toBe(1);
   });
   it('should be able to fake-add two users to a list', async () => {
-    let res = await repo.addGroupMembers(emailsToAdd2, testGroupName, 'test');
+    let res = await repo.addGroupMembers(emailsToAdd2, testGroupId, 'test');
     expect(res).toHaveProperty('status');
     expect(res.status).toBe('success');
     expect(res).toHaveProperty('message');
@@ -58,7 +60,7 @@ describe('AdobeUserMgmtRepository: addMembersToGroup', () => {
     expect(res.message.completedInTestMode).toBe(2);
   });
   it('should fail to fake-add fakeuser to a list', async () => {
-    let res = await repo.addGroupMembers(emailsFake1, testGroupName, 'test');
+    let res = await repo.addGroupMembers(emailsFake1, testGroupId, 'test');
     expect(res).toHaveProperty('status');
     expect(res.status).toBe('error');
     expect(res).toHaveProperty('message');
@@ -73,7 +75,7 @@ describe('AdobeUserMgmtRepository: addMembersToGroup', () => {
   it('should be able to add more than 10 users at once (chunked into sep calls)', async () => {
     // sleep 3000ms to avoid rate limit
     await new Promise((r) => setTimeout(r, 3000));
-    let res = await repo.addGroupMembers(emailsBigList, testGroupName, 'test');
+    let res = await repo.addGroupMembers(emailsBigList, testGroupId, 'test');
     expect(res).toHaveProperty('status');
     expect(res.status).toBe('success');
     expect(res).toHaveProperty('message');


### PR DESCRIPTION
* closes #57 
* expects `appConf.js` to include vendorGroupId in addition to vendorGroupName for Adobe groups
  * this change is reflected in `AdobeService` and `adobe.demo.js`
* makes the `adobeApi-async` test more agnostic -- it previously hard-coded the emails of specific users at Miami. To make the test more usable outside of Miami, the specifics of the test usernames are now in a config file `config/test/adobe.testConf.js` 