### PR TITLE
emailConverterService fail gracefully

### DIFF
--- a/helpers/database.js
+++ b/helpers/database.js
@@ -26,7 +26,8 @@ const conf = (module.exports = {
       await mongoose.connect(connectionString, config);
       console.log('database connected');
     } catch (err) {
-      console.log(err);
+      console.log('could not connect to database');
+      logger.error('could not connect to database: ', err);
     }
   },
 
@@ -35,7 +36,8 @@ const conf = (module.exports = {
       await mongoose.connection.close();
       console.log('database disconnected');
     } catch (err) {
-      console.log(err);
+      console.log('could not disconnect from database');
+      logger.error('could not disconnect from database:', err);
     }
   },
 });

--- a/services/emailConverterService.js
+++ b/services/emailConverterService.js
@@ -8,57 +8,79 @@ const process = require('process');
 let pid = process.pid;
 
 /*
+The purpose of this service to get the authoritative email address for a given email address. 
+The given address may be an alias. Authoritative email addresses are stored in the database,
+and can be retrieved from the emailConverter API. We request them from the API once and store
+them in the database for future use.
+
 - take in an array of emails
     - request authoritative emails from db
-    - request any stragglers from emailConverter API
+    - for any previously unknown emails, request authoritative email from emailConverter API
 - return array of authoritative emails
 - log any remaining stragglers to error log
+- if there are any new emails, add them to the db
+- if this process fails, return the original emails [most will still be valid, so better this than nothing]
 */
 
 module.exports = async (emails) => {
-  logger.info(`starting emailConverterService (pid:${pid})`);
-  await emailRepo.connect();
-  logger.info(`emailConverterService connected to db (pid:${pid})`);
-  // currently the querySpecificEmails option is getting an error
-  // knownEmails = await emailRepo.querySpecificEmails(emails);
-  // alternate definition may or may not result in a faster process
-  logger.info(`emailConverterService querying db (pid:${pid})`);
-  knownEmails = await emailRepo.queryAllEmails();
-  logger.info(`emailConverterService query complete (pid:${pid})`, {
-    queryResults: knownEmails.length,
-  });
-  // let knownEmails = []; //comment this out when you uncomment the above
-  let { found, missing } = await emailRepo.getKnownAndUnknownEmails(
-    emails,
-    knownEmails
-  );
-
-  let authoritativeEmails = found;
-
-  logger.info(`emailConverterService sorting results (pid:${pid})`, {
-    found: found.length,
-    missing: missing.length,
-  });
-  let { authFound, authMissing, newMatches } =
-    await convertRepo.getAuthoritativeEmailsBatch(missing);
-
-  logger.info(
-    `emailConverterService finished getAuthoritativeEmailsBatch (pid:${pid})`,
-    { found: found.length, missing: missing.length }
-  );
-
-  if (newMatches.length > 0) {
-    logger.info('adding new emails pairs with', newMatches);
-    await emailRepo.addNewEmailPairs(newMatches);
-  }
-  if (authMissing.length > 0) {
-    logger.error('Failed to get authoritative emails for:', {
-      missing: authMissing,
+  try {
+    logger.info(`starting emailConverterService (pid:${pid})`);
+    await emailRepo.connect();
+    logger.info(`emailConverterService connected to db (pid:${pid})`);
+    // currently the querySpecificEmails option is getting an error
+    // knownEmails = await emailRepo.querySpecificEmails(emails);
+    // alternate definition may or may not result in a faster process
+    logger.info(`emailConverterService querying db (pid:${pid})`);
+    knownEmails = await emailRepo.queryAllEmails();
+    logger.info(`emailConverterService query complete (pid:${pid})`, {
+      queryResults: knownEmails.length,
     });
+    // let knownEmails = []; //comment this out when you uncomment the above
+
+    let { found, missing } = await emailRepo.getKnownAndUnknownEmails(
+      emails,
+      knownEmails
+    );
+
+    let authoritativeEmails = found;
+
+    logger.info(`emailConverterService sorting results (pid:${pid})`, {
+      found: found.length,
+      missing: missing.length,
+    });
+
+    // authFound = array of emails we found matches for in the converter API
+    // authMissing = array of emails with no match
+    // newMatches = array of pairs: email & uniqEmail (these are the same emails as authFound, but with more info to pass to the db)
+    let { authFound, authMissing, newMatches } =
+      await convertRepo.getAuthoritativeEmailsBatch(missing);
+
+    logger.info(
+      `emailConverterService finished getAuthoritativeEmailsBatch (pid:${pid})`,
+      { found: found.length, missing: missing.length }
+    );
+
+    if (newMatches.length > 0) {
+      logger.info('adding new emails pairs with', newMatches);
+      await emailRepo.addNewEmailPairs(newMatches);
+    }
+    if (authMissing.length > 0) {
+      logger.error('Failed to get authoritative emails for:', {
+        missing: authMissing,
+      });
+    }
+
+    await emailRepo.disconnect();
+
+    logger.info(`emailConverterService.js finished (pid:${pid})`);
+    // return the list of authoritativeEmails from the datbase
+    // plus the list of authFound from the API
+    return authoritativeEmails.concat(authFound);
+  } catch (err) {
+    logger.error(
+      'emailConverterService.js failed; returning original emails instead of converted ones:',
+      err
+    );
+    return emails;
   }
-
-  await emailRepo.disconnect();
-
-  logger.info(`emailConverterService.js finished (pid:${pid})`);
-  return authoritativeEmails.concat(authFound);
 };


### PR DESCRIPTION
* closes #60 
* better logging of database connect/query failures
* when emailConverterService fails, it returns the emails passed to it instead of failing out -- most of the time, most of those emails will still work. Any leftovers will try again on the next pass. Better than failing entirely. 