### PR TITLE
use authoritative emails in admin dashboard "Compare" functions

### DIFF
--- a/www/routes/api.js
+++ b/www/routes/api.js
@@ -5,6 +5,7 @@ const appConf = require('../../config/appConf');
 const LicenseGroup = require('../../helpers/LicenseGroup');
 const lg = new LicenseGroup(appConf);
 const LogQuerier = require('../../models/LogQuerier');
+const emailConverterService = require('../../services/emailConverterService');
 const {
   filterToEntriesMissingFromSecondArray,
 } = require('../../helpers/utils');
@@ -108,7 +109,8 @@ router.get('/adobe/compare', async (req, res) => {
   const adobeEmails = adobeBookings.map((i) => i.email);
   const libCalBookings = await getLibCalBookingsByCid(cid);
 
-  const libCalEmails = libCalBookings.map((i) => i.email);
+  let libCalEmails = libCalBookings.map((i) => i.email);
+  libCalEmails = await emailConverterService(libCalEmails);
   let emailsToRemove = filterToEntriesMissingFromSecondArray(
     adobeEmails,
     libCalEmails

--- a/www/routes/api.js
+++ b/www/routes/api.js
@@ -12,6 +12,7 @@ const {
 const path = require('path');
 const fs = require('fs');
 const { Parser } = require('json2csv');
+const libCal = require('../../config/libCal');
 
 async function getAdobeBookingsByGroup(group) {
   const adobeConf = require('../../config/adobe');
@@ -150,7 +151,8 @@ router.get('/jamf/compare', async (req, res) => {
   }
   let jamfEmails = await getJamfBookingsByGroupId(req.query.group);
   const libCalBookings = await getLibCalBookingsByCid(req.query.cid);
-  const libCalEmails = libCalBookings.map((i) => i.email);
+  let libCalEmails = libCalBookings.map((i) => i.email);
+  libCalEmails = await emailConverterService(libCalEmails);
   let emailsToRemove = filterToEntriesMissingFromSecondArray(
     jamfEmails,
     libCalEmails


### PR DESCRIPTION
* closes #155 
* uses the emailConverterService on LibCal emails before comparing emails to Adobe & Jamf checkout lists in admin dashboard