### PR TITLE
improve display of time waiting for access in admin dashboard "compare" function

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express-session": "^1.18.0",
     "fast-xml-parser": "^4.2.7",
     "https": "^1.0.0",
+    "humanize-duration": "^3.33.0",
     "inquirer": "^8.2.1",
     "jsdom": "^24.1.0",
     "json2csv": "^6.0.0-alpha.2",

--- a/www/routes/api.js
+++ b/www/routes/api.js
@@ -30,10 +30,32 @@ async function getLibCalBookingsByCid(cid) {
   let bookings = await libcal.getCurrentValidBookings(cid);
   // calculate time waiting for license assignment, add it to the object
   bookings = bookings.map((i) => {
-    i.timeWaiting = i.created
-      ? humanizeDuration(dayjs().diff(dayjs(i.created), 'seconds') * 1000, {
-          units: ['d', 'h', 'm', 's'],
-        })
+    let waitTimeStarted;
+    // calculate wait time started based on when the request was created
+    // unless it was created in advance of the fromDate, in which case
+    // use the fromDate as the start of the wait time (they start waiting
+    // once the reservation starts, not when they request it)
+    if (i.hasOwnProperty('created') && i.hasOwnProperty('fromDate')) {
+      if (i.fromDate > i.created) {
+        waitTimeStarted = i.fromDate;
+      } else {
+        waitTimeStarted = i.created;
+      }
+    } else if (i.hasOwnProperty('created')) {
+      waitTimeStarted = i.created;
+    } else if (i.hasOwnProperty('fromDate')) {
+      waitTimeStarted = i.fromDate;
+    } else {
+      waitTimeStarted = null;
+    }
+
+    i.timeWaiting = waitTimeStarted
+      ? humanizeDuration(
+          dayjs().diff(dayjs(waitTimeStarted), 'seconds') * 1000,
+          {
+            units: ['d', 'h', 'm', 's'],
+          }
+        )
       : null;
     return i;
   });

--- a/www/routes/api.js
+++ b/www/routes/api.js
@@ -1,4 +1,5 @@
 const dayjs = require('dayjs');
+const humanizeDuration = require('humanize-duration');
 const express = require('express');
 const router = express.Router();
 const appConf = require('../../config/appConf');
@@ -30,7 +31,9 @@ async function getLibCalBookingsByCid(cid) {
   // calculate time waiting for license assignment, add it to the object
   bookings = bookings.map((i) => {
     i.timeWaiting = i.created
-      ? dayjs().diff(dayjs(i.created), 'minutes') + ' minutes'
+      ? humanizeDuration(dayjs().diff(dayjs(i.created), 'seconds') * 1000, {
+          units: ['d', 'h', 'm', 's'],
+        })
       : null;
     return i;
   });


### PR DESCRIPTION
* base wait time on time created or when reservation started, whichever is more recent, closes #151 
* make wait times more human readable (using appropriate units, not always in minutes -- if it's been a few days, say so.), closes #147 